### PR TITLE
Fix non-const lvalue reference error in init() function

### DIFF
--- a/cpp/include/ecal_camera/CameraInterface.hpp
+++ b/cpp/include/ecal_camera/CameraInterface.hpp
@@ -19,7 +19,7 @@ template <typename T>
 class MessageSynchroniserExact {
 
   public:
-    void init(size_t N, std::vector<std::string> &names = {}, std::string prefix = {}) {
+    void init(size_t N, const std::vector<std::string> &names = {}, std::string prefix = {}) {
         m_N = N;
         if (names.size()) {
             assert(names.size() == N);


### PR DESCRIPTION
This PR resolves the non-const lvalue reference error encountered in the init() function. The error occurred when attempting to pass an initializer list to a non-const lvalue reference parameter of type std::vector<std::string>.

To fix the issue, the parameter type has been changed to a const lvalue reference, allowing it to accept initializer lists. 